### PR TITLE
Organizing code

### DIFF
--- a/.github/workflows/parallel.yml
+++ b/.github/workflows/parallel.yml
@@ -9,14 +9,13 @@ jobs:
       fail-fast: false
       matrix:
         php: [ '8.0', '8.1', '8.2', '8.3' ]
-        ts: [ ts ]
     steps:
       - name: checkout
         uses: actions/checkout@v3
       - name: build
         # script parameters $extension $repo $branch $dev_branch $args $sdk_version $vs $arch $ts $php
         run: |
-          pwsh scripts/parallel.ps1 parallel krakjoe/parallel release develop with-parallel master vs16 x64 ${{ matrix.ts }} ${{ matrix.php }}
+          pwsh scripts/parallel.ps1 parallel krakjoe/parallel release develop with-parallel master vs16 x64 ts ${{ matrix.php }}
           $exit_code = $?
           if(-not($exit_code)) {
             exit $exit_code
@@ -24,7 +23,7 @@ jobs:
       - name: Upload Artifact
         uses: actions/upload-artifact@v2
         with:
-          name: parallel_${{ matrix.ts }}_x64
+          name: parallel_ts_x64
           path: parallel
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/parallel.yml
+++ b/.github/workflows/parallel.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - run: mkdir ext
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           path: ext
       - name: Release

--- a/.github/workflows/parallel.yml
+++ b/.github/workflows/parallel.yml
@@ -21,8 +21,9 @@ jobs:
             exit $exit_code
           }
       - name: Upload Artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
+          if-no-files-found: error
           name: parallel_ts_x64
           path: parallel
   release:

--- a/.github/workflows/parallel.yml
+++ b/.github/workflows/parallel.yml
@@ -16,7 +16,7 @@ jobs:
       - name: build
         # script parameters $extension $repo $branch $dev_branch $args $sdk_version $vs $arch $ts $php
         run: |
-          pwsh scripts/parallel.ps1 parallel krakjoe/parallel release with-parallel master vs16 x64 ${{ matrix.ts }} ${{ matrix.php }}
+          pwsh scripts/parallel.ps1 parallel krakjoe/parallel release develop with-parallel master vs16 x64 ${{ matrix.ts }} ${{ matrix.php }}
           $exit_code = $?
           if(-not($exit_code)) {
             exit $exit_code

--- a/.github/workflows/parallel.yml
+++ b/.github/workflows/parallel.yml
@@ -8,52 +8,44 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['8.0', '8.1', '8.2', '8.3']
-        extensions: [parallel]
-        sdk_version: [master]
-        vs: [vs16]
-        ts: [ts]
-        arch: [x64]
-        include:
-          - extensions: parallel
-            repo: krakjoe/parallel
-            branch: release
-            args: with-parallel
+        php: [ '8.0', '8.1', '8.2', '8.3' ]
+        ts: [ ts ]
     steps:
-    - name: checkout
-      uses: actions/checkout@v3
-    - name: build
-      run: |
-        pwsh scripts/parallel.ps1 ${{ matrix.extensions }} ${{ matrix.repo }} ${{ matrix.branch }} ${{ matrix.args }} ${{ matrix.sdk_version }} ${{ matrix.vs }} ${{ matrix.arch }} ${{ matrix.ts }} ${{ matrix.php }}
-        $exit_code = $?
-        if(-not($exit_code)) {
-          exit $exit_code
-        }
-    - name: Upload Artifact
-      uses: actions/upload-artifact@v2
-      with:
-        name: ${{ matrix.extensions }}_${{ matrix.ts }}_${{ matrix.arch }}
-        path: ${{ matrix.extensions }}
+      - name: checkout
+        uses: actions/checkout@v3
+      - name: build
+        # script parameters $extension $repo $branch $dev_branch $args $sdk_version $vs $arch $ts $php
+        run: |
+          pwsh scripts/parallel.ps1 parallel krakjoe/parallel release with-parallel master vs16 x64 ${{ matrix.ts }} ${{ matrix.php }}
+          $exit_code = $?
+          if(-not($exit_code)) {
+            exit $exit_code
+          }
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: parallel_${{ matrix.ts }}_x64
+          path: parallel
   release:
     runs-on: ubuntu-latest
     needs: build
     steps:
-    - uses: actions/checkout@v3
-    - run: mkdir ext
-    - uses: actions/download-artifact@v2
-      with:
-        path: ext
-    - name: Release
-      run: |
-        set -x
-        assets=()
-        for asset in ./ext/*/*.dll; do
-          assets+=("$asset")
-        done
-        if ! gh release view Parallel; then
-          gh release create "Parallel" "${assets[@]}" -t "Parallel" -n "Parallel"
-        else
-          gh release upload "Parallel" "${assets[@]}" --clobber
-        fi
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/checkout@v3
+      - run: mkdir ext
+      - uses: actions/download-artifact@v2
+        with:
+          path: ext
+      - name: Release
+        run: |
+          set -x
+          assets=()
+          for asset in ./ext/*/*.dll; do
+            assets+=("$asset")
+          done
+          if ! gh release view Parallel; then
+            gh release create "Parallel" "${assets[@]}" -t "Parallel" -n "Parallel"
+          else
+            gh release upload "Parallel" "${assets[@]}" --clobber
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pcov.yml
+++ b/.github/workflows/pcov.yml
@@ -8,51 +8,44 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['8.0', '8.1', '8.2', '8.3']
-        extensions: [pcov]
-        sdk_version: [master]
-        vs: [vs16]
-        ts: [ts, nts]
-        arch: [x64]
-        include:
-          - extensions: pcov
-            repo: krakjoe/pcov
-            branch: release
-            args: enable-pcov
+        php: [ '8.0', '8.1', '8.2', '8.3' ]
+        ts: [ ts, nts ]
     steps:
-    - uses: actions/checkout@v3
-    - name: build
-      run: |
-        pwsh scripts/builder.ps1 ${{ matrix.extensions }} ${{ matrix.repo }} ${{ matrix.branch }} ${{ matrix.args }} ${{ matrix.sdk_version }} ${{ matrix.vs }} ${{ matrix.arch }} ${{ matrix.ts }} ${{ matrix.php }}
-        $exit_code = $?
-        if(-not($exit_code)) {
-          exit $exit_code
-        }
-    - name: Upload Artifact
-      uses: actions/upload-artifact@v2
-      with:
-        name: ${{ matrix.extensions }}_${{ matrix.ts }}_${{ matrix.arch }}
-        path: ${{ matrix.extensions }}
+      - name: checkout
+        uses: actions/checkout@v3
+      - name: build
+        # script parameters $extension $repo $branch $dev_branch $args $sdk_version $vs $arch $ts $php
+        run: |
+          pwsh scripts/builder.ps1 pcov krakjoe/pcov release develop enable-pcov master vs16 x64 ${{ matrix.ts }} ${{ matrix.php }}
+          $exit_code = $?
+          if(-not($exit_code)) {
+            exit $exit_code
+          }
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ matrix.extensions }}_${{ matrix.ts }}_${{ matrix.arch }}
+          path: ${{ matrix.extensions }}
   release:
     runs-on: ubuntu-latest
     needs: build
     steps:
-    - uses: actions/checkout@v3
-    - run: mkdir ext
-    - uses: actions/download-artifact@v2
-      with:
-        path: ext
-    - name: Release
-      run: |
-        set -x
-        assets=()
-        for asset in ./ext/*/*.dll; do
-          assets+=("$asset")
-        done
-        if ! gh release view pCov; then
-          gh release create "pCov" "${assets[@]}" -t "pCov" -n "pCov"
-        else
-          gh release upload "pCov" "${assets[@]}" --clobber
-        fi
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/checkout@v3
+      - run: mkdir ext
+      - uses: actions/download-artifact@v2
+        with:
+          path: ext
+      - name: Release
+        run: |
+          set -x
+          assets=()
+          for asset in ./ext/*/*.dll; do
+            assets+=("$asset")
+          done
+          if ! gh release view pCov; then
+            gh release create "pCov" "${assets[@]}" -t "pCov" -n "pCov"
+          else
+            gh release upload "pCov" "${assets[@]}" --clobber
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pcov.yml
+++ b/.github/workflows/pcov.yml
@@ -24,8 +24,8 @@ jobs:
       - name: Upload Artifact
         uses: actions/upload-artifact@v2
         with:
-          name: ${{ matrix.extensions }}_${{ matrix.ts }}_${{ matrix.arch }}
-          path: ${{ matrix.extensions }}
+          name: pcov_${{ matrix.ts }}_x64
+          path: pcov
   release:
     runs-on: ubuntu-latest
     needs: build

--- a/.github/workflows/pcov.yml
+++ b/.github/workflows/pcov.yml
@@ -33,7 +33,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - run: mkdir ext
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           path: ext
       - name: Release

--- a/.github/workflows/pcov.yml
+++ b/.github/workflows/pcov.yml
@@ -22,8 +22,9 @@ jobs:
             exit $exit_code
           }
       - name: Upload Artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
+          if-no-files-found: error
           name: pcov_${{ matrix.ts }}_x64
           path: pcov
   release:

--- a/.github/workflows/tensor.yml
+++ b/.github/workflows/tensor.yml
@@ -22,8 +22,9 @@ jobs:
             exit $exit_code
           }
       - name: Upload Artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
+          if-no-files-found: error
           name: tensor_${{ matrix.ts }}_x64
           path: tensor
   release:

--- a/.github/workflows/tensor.yml
+++ b/.github/workflows/tensor.yml
@@ -24,8 +24,8 @@ jobs:
       - name: Upload Artifact
         uses: actions/upload-artifact@v2
         with:
-          name: ${{ matrix.extensions }}_${{ matrix.ts }}_${{ matrix.arch }}
-          path: ${{ matrix.extensions }}
+          name: tensor_${{ matrix.ts }}_x64
+          path: tensor
   release:
     runs-on: ubuntu-latest
     needs: build

--- a/.github/workflows/tensor.yml
+++ b/.github/workflows/tensor.yml
@@ -16,7 +16,7 @@ jobs:
       - name: build
         # script parameters $extension $repo $branch $dev_branch $args $sdk_version $vs $arch $ts $php
         run: |
-          pwsh scripts/tensor.ps1 tensor RubixML/Tensor master enable-tensor master vs16 x64 ${{ matrix.ts }} ${{ matrix.php }}
+          pwsh scripts/tensor.ps1 tensor RubixML/Tensor master master enable-tensor master vs16 x64 ${{ matrix.ts }} ${{ matrix.php }}
           $exit_code = $?
           if(-not($exit_code)) {
             exit $exit_code

--- a/.github/workflows/tensor.yml
+++ b/.github/workflows/tensor.yml
@@ -33,7 +33,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - run: mkdir ext
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           path: ext
       - name: Release

--- a/.github/workflows/tensor.yml
+++ b/.github/workflows/tensor.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [ '8.0', '8.1', '8.2', '8.3' ]
+        php: [ '8.0', '8.1' ]
         ts: [ ts, nts ]
     steps:
       - name: checkout

--- a/.github/workflows/tensor.yml
+++ b/.github/workflows/tensor.yml
@@ -8,51 +8,44 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['8.0', '8.1', '8.2', '8.3']
-        extensions: [tensor]
-        sdk_version: [master]
-        vs: [vs16]
-        ts: [ts, nts]
-        arch: [x64]
-        include:
-          - extensions: tensor
-            repo:  RubixML/Tensor
-            branch: master
-            args: enable-tensor
+        php: [ '8.0', '8.1', '8.2', '8.3' ]
+        ts: [ ts, nts ]
     steps:
-    - uses: actions/checkout@v3
-    - name: build
-      run: |
-        pwsh scripts/tensor.ps1 ${{ matrix.extensions }} ${{ matrix.repo }} ${{ matrix.branch }} ${{ matrix.args }} ${{ matrix.sdk_version }} ${{ matrix.vs }} ${{ matrix.arch }} ${{ matrix.ts }} ${{ matrix.php }}
-        $exit_code = $?
-        if(-not($exit_code)) {
-          exit $exit_code
-        }
-    - name: Upload Artifact
-      uses: actions/upload-artifact@v2
-      with:
-        name: ${{ matrix.extensions }}_${{ matrix.ts }}_${{ matrix.arch }}
-        path: ${{ matrix.extensions }}
+      - name: checkout
+        uses: actions/checkout@v3
+      - name: build
+        # script parameters $extension $repo $branch $dev_branch $args $sdk_version $vs $arch $ts $php
+        run: |
+          pwsh scripts/tensor.ps1 tensor RubixML/Tensor master enable-tensor master vs16 x64 ${{ matrix.ts }} ${{ matrix.php }}
+          $exit_code = $?
+          if(-not($exit_code)) {
+            exit $exit_code
+          }
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ matrix.extensions }}_${{ matrix.ts }}_${{ matrix.arch }}
+          path: ${{ matrix.extensions }}
   release:
     runs-on: ubuntu-latest
     needs: build
     steps:
-    - uses: actions/checkout@v3
-    - run: mkdir ext
-    - uses: actions/download-artifact@v2
-      with:
-        path: ext
-    - name: Release
-      run: |
-        set -x
-        assets=()
-        for asset in ./ext/*/*.dll; do
-          assets+=("$asset")
-        done
-        if ! gh release view Tensor; then
-          gh release create "Tensor" "${assets[@]}" -t "Tensor" -n "Tensor"
-        else
-          gh release upload "Tensor" "${assets[@]}" --clobber
-        fi
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/checkout@v3
+      - run: mkdir ext
+      - uses: actions/download-artifact@v2
+        with:
+          path: ext
+      - name: Release
+        run: |
+          set -x
+          assets=()
+          for asset in ./ext/*/*.dll; do
+            assets+=("$asset")
+          done
+          if ! gh release view Tensor; then
+            gh release create "Tensor" "${assets[@]}" -t "Tensor" -n "Tensor"
+          else
+            gh release upload "Tensor" "${assets[@]}" --clobber
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/trader.yml
+++ b/.github/workflows/trader.yml
@@ -24,8 +24,8 @@ jobs:
       - name: Upload Artifact
         uses: actions/upload-artifact@v2
         with:
-          name: ${{ matrix.extensions }}_${{ matrix.ts }}_${{ matrix.arch }}
-          path: ${{ matrix.extensions }}
+          name: trader_${{ matrix.ts }}_x64
+          path: trader
   release:
     runs-on: ubuntu-latest
     needs: build

--- a/.github/workflows/trader.yml
+++ b/.github/workflows/trader.yml
@@ -22,8 +22,9 @@ jobs:
             exit $exit_code
           }
       - name: Upload Artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
+          if-no-files-found: error
           name: trader_${{ matrix.ts }}_x64
           path: trader
   release:

--- a/.github/workflows/trader.yml
+++ b/.github/workflows/trader.yml
@@ -33,7 +33,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - run: mkdir ext
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           path: ext
       - name: Release

--- a/.github/workflows/trader.yml
+++ b/.github/workflows/trader.yml
@@ -8,51 +8,44 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['8.0', '8.1', '8.2', '8.3']
-        extensions: [trader]
-        sdk_version: [master]
-        vs: [vs16]
-        ts: [ts, nts]
-        arch: [x64]
-        include:
-          - extensions: trader
-            repo:   php/pecl-math-trader
-            branch: master
-            args: enable-trader
+        php: [ '8.0', '8.1', '8.2', '8.3' ]
+        ts: [ ts, nts ]
     steps:
-    - uses: actions/checkout@v3
-    - name: build
-      run: |
-        pwsh scripts/builder.ps1 ${{ matrix.extensions }} ${{ matrix.repo }} ${{ matrix.branch }} ${{ matrix.dev_branch }} ${{ matrix.args }} ${{ matrix.sdk_version }} ${{ matrix.vs }} ${{ matrix.arch }} ${{ matrix.ts }} ${{ matrix.php }}
-        $exit_code = $?
-        if(-not($exit_code)) {
-          exit $exit_code
-        }
-    - name: Upload Artifact
-      uses: actions/upload-artifact@v2
-      with:
-        name: ${{ matrix.extensions }}_${{ matrix.ts }}_${{ matrix.arch }}
-        path: ${{ matrix.extensions }}
+      - name: checkout
+        uses: actions/checkout@v3
+      - name: build
+        # script parameters $extension $repo $branch $dev_branch $args $sdk_version $vs $arch $ts $php
+        run: |
+          pwsh scripts/builder.ps1 trader php/pecl-math-trader master master enable-trader master vs16 x64 ${{ matrix.ts }} ${{ matrix.php }}
+          $exit_code = $?
+          if(-not($exit_code)) {
+            exit $exit_code
+          }
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ matrix.extensions }}_${{ matrix.ts }}_${{ matrix.arch }}
+          path: ${{ matrix.extensions }}
   release:
     runs-on: ubuntu-latest
     needs: build
     steps:
-    - uses: actions/checkout@v3
-    - run: mkdir ext
-    - uses: actions/download-artifact@v2
-      with:
-        path: ext
-    - name: Release
-      run: |
-        set -x
-        assets=()
-        for asset in ./ext/*/*.dll; do
-          assets+=("$asset")
-        done
-        if ! gh release view Trader; then
-          gh release create "Trader" "${assets[@]}" -t "Trader" -n "Trader"
-        else
-          gh release upload "Trader" "${assets[@]}" --clobber
-        fi
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/checkout@v3
+      - run: mkdir ext
+      - uses: actions/download-artifact@v2
+        with:
+          path: ext
+      - name: Release
+        run: |
+          set -x
+          assets=()
+          for asset in ./ext/*/*.dll; do
+            assets+=("$asset")
+          done
+          if ! gh release view Trader; then
+            gh release create "Trader" "${assets[@]}" -t "Trader" -n "Trader"
+          else
+            gh release upload "Trader" "${assets[@]}" --clobber
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/xdebug.yml
+++ b/.github/workflows/xdebug.yml
@@ -24,8 +24,8 @@ jobs:
       - name: Upload Artifact
         uses: actions/upload-artifact@v2
         with:
-          name: ${{ matrix.extensions }}_${{ matrix.ts }}_${{ matrix.arch }}
-          path: ${{ matrix.extensions }}
+          name: xdebug_${{ matrix.ts }}_x64
+          path: xdebug
   release:
     runs-on: ubuntu-latest
     needs: build

--- a/.github/workflows/xdebug.yml
+++ b/.github/workflows/xdebug.yml
@@ -22,8 +22,9 @@ jobs:
             exit $exit_code
           }
       - name: Upload Artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
+          if-no-files-found: error
           name: xdebug_${{ matrix.ts }}_x64
           path: xdebug
   release:

--- a/.github/workflows/xdebug.yml
+++ b/.github/workflows/xdebug.yml
@@ -8,51 +8,44 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['8.0', '8.1', '8.2', '8.3']
-        extensions: [xdebug]
-        sdk_version: [master]
-        vs: [vs16]
-        ts: [ts, nts]
-        arch: [x64]
-        include:
-          - extensions: xdebug
-            repo: xdebug/xdebug
-            branch: master
-            args: with-xdebug
+        php: [ '8.0', '8.1', '8.2', '8.3' ]
+        ts: [ ts, nts ]
     steps:
-    - uses: actions/checkout@v3
-    - name: build
-      run: |
-        pwsh scripts/builder.ps1 ${{ matrix.extensions }} ${{ matrix.repo }} ${{ matrix.branch }} ${{ matrix.args }} ${{ matrix.sdk_version }} ${{ matrix.vs }} ${{ matrix.arch }} ${{ matrix.ts }} ${{ matrix.php }}
-        $exit_code = $?
-        if(-not($exit_code)) {
-          exit $exit_code
-        }
-    - name: Upload Artifact
-      uses: actions/upload-artifact@v2
-      with:
-        name: ${{ matrix.extensions }}_${{ matrix.ts }}_${{ matrix.arch }}
-        path: ${{ matrix.extensions }}
+      - name: checkout
+        uses: actions/checkout@v3
+      - name: build
+        # script parameters $extension $repo $branch $dev_branch $args $sdk_version $vs $arch $ts $php
+        run: |
+          pwsh scripts/builder.ps1 xdebug xdebug/xdebug master xdebug_3_2 with-xdebug master vs16 x64 ${{ matrix.ts }} ${{ matrix.php }}
+          $exit_code = $?
+          if(-not($exit_code)) {
+            exit $exit_code
+          }
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ matrix.extensions }}_${{ matrix.ts }}_${{ matrix.arch }}
+          path: ${{ matrix.extensions }}
   release:
     runs-on: ubuntu-latest
     needs: build
     steps:
-    - uses: actions/checkout@v3
-    - run: mkdir ext
-    - uses: actions/download-artifact@v2
-      with:
-        path: ext
-    - name: Release
-      run: |
-        set -x
-        assets=()
-        for asset in ./ext/*/*.dll; do
-          assets+=("$asset")
-        done
-        if ! gh release view xDebug; then
-          gh release create "xDebug" "${assets[@]}" -t "xDebug" -n "xDebug"
-        else
-          gh release upload "xDebug" "${assets[@]}" --clobber
-        fi
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/checkout@v3
+      - run: mkdir ext
+      - uses: actions/download-artifact@v2
+        with:
+          path: ext
+      - name: Release
+        run: |
+          set -x
+          assets=()
+          for asset in ./ext/*/*.dll; do
+            assets+=("$asset")
+          done
+          if ! gh release view xDebug; then
+            gh release create "xDebug" "${assets[@]}" -t "xDebug" -n "xDebug"
+          else
+            gh release upload "xDebug" "${assets[@]}" --clobber
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/xdebug.yml
+++ b/.github/workflows/xdebug.yml
@@ -33,7 +33,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - run: mkdir ext
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           path: ext
       - name: Release

--- a/scripts/builder.ps1
+++ b/scripts/builder.ps1
@@ -39,7 +39,9 @@ param (
     [ValidateLength(1, [int]::MaxValue)]
     [string]
     $arch,
-    [Parameter(Position = 8, Mandatory = $false)]
+    [Parameter(Position = 8, Mandatory = $true)]
+    [ValidateNotNull()]
+    [ValidateLength(1, [int]::MaxValue)]
     [string]
     $ts,
     [Parameter(Position = 9, Mandatory = $true)]
@@ -49,156 +51,19 @@ param (
     $php
 )
 
-Function Cleanup() {
-    if(Test-Path $ext_dir) {
-        Remove-Item $ext_dir -Recurse -Force
-    }
-    if(Test-Path $cache_dir) {
-        Remove-Item $cache_dir -Recurse -Force
-    }
-    New-Item -Path $cache_dir -ItemType "directory"
+Import-Module ".\scripts\builder.psm1"
+
+$buildParams = @{
+    extension = $extension
+    repo = $repo
+    branch = $branch
+    dev_branch = $dev_branch
+    config_args = $config_args
+    sdk_version = $sdk_version
+    vs = $vs
+    arch = $arch
+    ts = $ts
+    php = $php
 }
 
-Function Get-Extension() {
-    if($php -ne $nightly_version) {
-        git clone --branch=$branch $github/$repo.git $ext_dir
-    } else {
-        git clone --branch=$dev_branch $github/$repo.git $ext_dir
-    }
-}
-
-Function Get-Package {
-    param (
-        [Parameter(Position = 0, Mandatory = $true)]
-        [ValidateNotNull()]
-        [ValidateLength(1, [int]::MaxValue)]
-        [string]
-        $package,
-        [Parameter(Position = 1, Mandatory = $true)]
-        [ValidateNotNull()]
-        [ValidateLength(1, [int]::MaxValue)]
-        [string]
-        $url,
-        [Parameter(Position = 2, Mandatory = $true)]
-        [ValidateNotNull()]
-        [ValidateLength(1, [int]::MaxValue)]
-        [string]
-        $tmp_dir,
-        [Parameter(Position = 3, Mandatory = $true)]
-        [ValidateNotNull()]
-        [ValidateLength(1, [int]::MaxValue)]
-        [string]
-        $package_dir
-    )
-    if (-not (Test-Path $cache_dir\$package)) {
-        Invoke-WebRequest $url -OutFile "$cache_dir\$package"
-    }
-
-    if (-not (Test-Path $package_dir)) {
-        Expand-Archive -Path $cache_dir\$package -DestinationPath $cache_dir -Force
-        if($tmp_dir -ne $package_dir) {
-            Rename-Item -Path $cache_dir\$tmp_dir -NewName $package_dir -Force
-        }
-    }
-}
-
-Function Add-TaskFile() {
-    param (
-        [Parameter(Position = 0, Mandatory = $true)]
-        [ValidateNotNull()]
-        [ValidateLength(1, [int]::MaxValue)]
-        [string]
-        $filename
-    )
-    $bat_content = @()
-    $bat_content += ""
-    $bat_content += "call phpize 2>&1"
-    $bat_content += "call configure --help"
-    $bat_content += "call configure --$config_args --enable-debug-pack 2>&1"
-    $bat_content += "nmake /nologo 2>&1"
-    $bat_content += "exit %errorlevel%"
-    Set-Content -Encoding "ASCII" -Path $filename -Value $bat_content
-}
-
-Function Get-TSPath() {
-    if($ts -eq 'nts') {
-        return '-nts'
-    }
-
-    return ''
-}
-
-Function Get-ReleaseDirectory() {
-    $arch_path = ''
-    if($arch -eq 'x64') {
-        $arch_path = 'x64'
-    }
-
-    $release_path = 'Release'
-    if($ts -eq 'ts') {
-        $release_path = 'Release_TS'
-    }
-
-    return [IO.Path]::Combine($arch_path, $release_path)
-}
-
-Function Get-PHPBranch() {
-    $php_branch = 'master'
-    if($php -ne $nightly_version) {
-        $php_branch = "PHP-$php"
-    }
-
-    return $php_branch
-}
-
-Function Build-Extension() {
-    $ts_path = Get-TSPath
-    $package_zip = "php-devel-pack-$php_version$ts_path-Win32-$vs-$arch.zip"
-    $tmp_dir = "php-$php_version-devel-$vs-$arch"
-    $package_dir = "php-$php_version$ts_path-devel-$vs-$arch"
-    $url = "$trunk/$package_zip"
-    Get-Package $package_zip $url $tmp_dir $package_dir
-
-    Set-Location $ext_dir
-    Add-TaskFile "task.bat"
-    $env:PATH = "$cache_dir\$package_dir;$env:PATH"
-    $builder = "$cache_dir\php-sdk-$sdk_version\phpsdk-$vs-$arch.bat"
-    $task = (Get-Item -Path "." -Verbose).FullName + '\task.bat'
-    & $builder -t $task
-}
-
-Function Copy-Extension() {
-    Set-Location $workspace
-    New-Item -Path $extension -ItemType "directory"
-    $release_dir = Get-ReleaseDirectory
-    $ext_path = [IO.Path]::Combine($ext_dir, $release_dir, "php_$extension.dll")
-    Write-Output "Extension Path: $ext_path"
-    if(Test-Path $ext_path) {
-        Copy-Item -Path $ext_path -Destination "$extension\php$php`_$ts`_$arch`_$extension.dll"
-        Get-ChildItem $extension
-    } else {
-        exit 1
-    }
-}
-
-$workspace = (Get-Location).Path
-$cache_dir = "C:\build-cache"
-$ext_dir = "C:\projects\$extension"
-$github = "https://github.com"
-$trunk = "$github/shivammathur/php-builder-windows/releases/download/php$php"
-$nightly_version = '8.3'
-$php_branch = Get-PHPBranch
-$php_version = Invoke-RestMethod "https://raw.githubusercontent.com/php/php-src/$php_branch/main/php_version.h" | Where-Object { $_  -match 'PHP_VERSION "(.*)"' } | Foreach-Object {$Matches[1]}
-$package_zip = "php-sdk-$sdk_version.zip"
-$tmp_dir = "php-sdk-binary-tools-php-sdk-$sdk_version"
-if($sdk_version -eq 'master') {
-    $package_zip = "master.zip"
-    $tmp_dir = "php-sdk-binary-tools-master"
-}
-$package_dir = "php-sdk-$sdk_version"
-$url = "$github/php/php-sdk-binary-tools/archive/$package_zip"
-Cleanup
-Get-Package $package_zip $url $tmp_dir $package_dir
-Get-Extension
-Build-Extension
-Copy-Extension
+RunBuilder $buildParams

--- a/scripts/builder.psm1
+++ b/scripts/builder.psm1
@@ -1,0 +1,182 @@
+class BuilderParameters
+{
+    [string] $extension
+    [string] $repo
+    [string] $branch
+    [string] $dev_branch
+    [string] $config_args
+    [string] $sdk_version
+    [string] $vs
+    [string] $arch
+    [string] $ts
+    [string] $php
+}
+
+Function PassBuildInformation([BuilderParameters]$buildParams)
+{
+    $script:extension = $buildParams.extension
+    $script:repo = $buildParams.repo
+    $script:branch = $buildParams.branch
+    $script:dev_branch = $buildParams.dev_branch
+    $script:config_args = $buildParams.config_args
+    $script:sdk_version = $buildParams.sdk_version
+    $script:vs = $buildParams.vs
+    $script:arch = $buildParams.arch
+    $script:ts = $buildParams.ts
+    $script:php = $buildParams.php
+}
+
+Function Cleanup([string]$ext_dir, [string]$cache_dir)
+{
+    if (Test-Path $ext_dir)
+    {
+        Remove-Item $ext_dir -Recurse -Force
+    }
+    if (Test-Path $cache_dir)
+    {
+        Remove-Item $cache_dir -Recurse -Force
+    }
+    New-Item -Path $cache_dir -ItemType "directory"
+}
+
+Function Get-Extension([string]$nightly_version, [string]$ext_dir)
+{
+    if ($php -ne $nightly_version)
+    {
+        git clone --branch=$branch $github/$repo.git $ext_dir
+    }
+    else
+    {
+        git clone --branch=$dev_branch $github/$repo.git $ext_dir
+    }
+}
+
+Function Get-BuildPackage([string]$package_zip, [string]$url, [string]$tmp_dir, [string]$package_dir)
+{
+    if (-not(Test-Path $cache_dir\$package_zip))
+    {
+        Invoke-WebRequest $url -OutFile $cache_dir\$package_zip
+    }
+
+    if (-not(Test-Path $package_dir))
+    {
+        Expand-Archive -Path $cache_dir\$package_zip -DestinationPath $cache_dir -Force
+        if ($tmp_dir -ne $package_dir)
+        {
+            Rename-Item -Path $cache_dir\$tmp_dir -NewName $package_dir -Force
+        }
+}
+}
+
+Function Add-TaskFile([string]$filename)
+{
+    $bat_content = @()
+    $bat_content += ""
+    $bat_content += "call phpize 2>&1"
+    $bat_content += "call configure --help"
+    $bat_content += "call configure --$config_args --enable-debug-pack 2>&1"
+    $bat_content += "nmake /nologo 2>&1"
+    $bat_content += "exit %errorlevel%"
+    Set-Content -Encoding "ASCII" -Path $filename -Value $bat_content
+}
+
+Function Get-TSPath()
+{
+    if ($ts -eq 'nts')
+    {
+        return '-nts'
+    }
+
+    return ''
+}
+
+Function Get-ReleaseDirectory()
+{
+    $arch_path = ''
+    if ($arch -eq 'x64')
+    {
+        $arch_path = 'x64'
+    }
+
+    $release_path = 'Release'
+    if ($ts -eq 'ts')
+    {
+        $release_path = 'Release_TS'
+    }
+
+    return [IO.Path]::Combine($arch_path, $release_path)
+}
+
+Function Get-PHPBranch([string]$nightly_version)
+{
+    $php_branch = 'master'
+    if ($php -ne $nightly_version)
+    {
+        $php_branch = "PHP-$php"
+    }
+
+    return $php_branch
+}
+
+Function Build-Extension([string]$trunk, [string]$php_version)
+{
+    $ts_path = Get-TSPath
+    $package_zip = "php-devel-pack-$php_version$ts_path-Win32-$vs-$arch.zip"
+    $tmp_dir = "php-$php_version-devel-$vs-$arch"
+    $package_dir = "php-$php_version$ts_path-devel-$vs-$arch"
+    $url = "$trunk/$package_zip"
+    Get-BuildPackage $package_zip $url $tmp_dir $package_dir
+
+    Set-Location $ext_dir
+    Add-TaskFile "task.bat"
+    $env:PATH = "$cache_dir\$package_dir;$env:PATH"
+    $builder = "$cache_dir\php-sdk-$sdk_version\phpsdk-$vs-$arch.bat"
+    $task = (Get-Item -Path "." -Verbose).FullName + '\task.bat'
+    & $builder -t $task
+}
+
+Function Copy-Extension([string]$workspace)
+{
+    Set-Location $workspace
+    New-Item -Path $extension -ItemType "directory"
+    $release_dir = Get-ReleaseDirectory
+    $ext_path = [IO.Path]::Combine($ext_dir, $release_dir, "php_$extension.dll")
+    Write-Output "Extension Path: $ext_path"
+    if (Test-Path $ext_path)
+    {
+        Copy-Item -Path $ext_path -Destination "$extension\php$php`_$ts`_$arch`_$extension.dll"
+        Get-ChildItem $extension
+    }
+    else
+    {
+        exit 1
+    }
+}
+
+Function RunBuilder([BuilderParameters]$buildParams)
+{
+    PassBuildInformation $buildParams
+
+    $workspace = (Get-Location).Path
+    $cache_dir = "C:\build-cache"
+    $ext_dir = "C:\projects\$extension"
+    $github = "https://github.com"
+    $trunk = "$github/shivammathur/php-builder-windows/releases/download/php$php"
+    $nightly_version = '8.3'
+    $php_branch = Get-PHPBranch $nightly_version
+    $php_version = Invoke-RestMethod "https://raw.githubusercontent.com/php/php-src/$php_branch/main/php_version.h" | Where-Object { $_  -match 'PHP_VERSION "(.*)"' } | Foreach-Object {$Matches[1]}
+    $package_zip = "php-sdk-$sdk_version.zip"
+    $tmp_dir = "php-sdk-binary-tools-$sdk_version"
+    if($sdk_version -eq 'master') {
+        $package_zip = "master.zip"
+        $tmp_dir = "php-sdk-binary-tools-master"
+    }
+    $package_dir = "php-sdk-$sdk_version"
+    $url = "$github/php/php-sdk-binary-tools/archive/$package_zip"
+    
+    Cleanup $ext_dir $cache_dir
+    Get-BuildPackage $package_zip $url $tmp_dir $package_dir
+    Get-Extension $nightly_version $ext_dir
+    Build-Extension $trunk $php_version
+    Copy-Extension $workspace    
+}

--- a/scripts/builder.psm1
+++ b/scripts/builder.psm1
@@ -157,22 +157,22 @@ Function RunBuilder([BuilderParameters]$buildParams)
 {
     PassBuildInformation $buildParams
 
-    $script:workspace = (Get-Location).Path
-    $script:cache_dir = "C:\build-cache"
-    $script:ext_dir = "C:\projects\$extension"
-    $script:github = "https://github.com"
-    $script:trunk = "$github/shivammathur/php-builder-windows/releases/download/php$php"
-    $script:nightly_version = '8.3'
-    $script:php_branch = Get-PHPBranch $nightly_version
-    $script:php_version = Invoke-RestMethod "https://raw.githubusercontent.com/php/php-src/$php_branch/main/php_version.h" | Where-Object { $_  -match 'PHP_VERSION "(.*)"' } | Foreach-Object {$Matches[1]}
-    $script:package_zip = "php-sdk-$sdk_version.zip"
-    $script:tmp_dir = "php-sdk-binary-tools-$sdk_version"
+    $global:workspace = (Get-Location).Path
+    $global:cache_dir = "C:\build-cache"
+    $global:ext_dir = "C:\projects\$extension"
+    $global:github = "https://github.com"
+    $global:trunk = "$github/shivammathur/php-builder-windows/releases/download/php$php"
+    $global:nightly_version = '8.3'
+    $global:php_branch = Get-PHPBranch $nightly_version
+    $global:php_version = Invoke-RestMethod "https://raw.githubusercontent.com/php/php-src/$php_branch/main/php_version.h" | Where-Object { $_  -match 'PHP_VERSION "(.*)"' } | Foreach-Object {$Matches[1]}
+    $global:package_zip = "php-sdk-$sdk_version.zip"
+    $global:tmp_dir = "php-sdk-binary-tools-$sdk_version"
     if($sdk_version -eq 'master') {
-        $script:package_zip = "master.zip"
-        $script:tmp_dir = "php-sdk-binary-tools-master"
+        $global:package_zip = "master.zip"
+        $global:tmp_dir = "php-sdk-binary-tools-master"
     }
-    $script:package_dir = "php-sdk-$sdk_version"
-    $script:url = "$github/php/php-sdk-binary-tools/archive/$package_zip"
+    $global:package_dir = "php-sdk-$sdk_version"
+    $global:url = "$github/php/php-sdk-binary-tools/archive/$package_zip"
 
     Cleanup $ext_dir $cache_dir
     Get-BuildPackage $package_zip $url $tmp_dir $package_dir

--- a/scripts/builder.psm1
+++ b/scripts/builder.psm1
@@ -157,26 +157,26 @@ Function RunBuilder([BuilderParameters]$buildParams)
 {
     PassBuildInformation $buildParams
 
-    $workspace = (Get-Location).Path
-    $cache_dir = "C:\build-cache"
-    $ext_dir = "C:\projects\$extension"
-    $github = "https://github.com"
-    $trunk = "$github/shivammathur/php-builder-windows/releases/download/php$php"
-    $nightly_version = '8.3'
-    $php_branch = Get-PHPBranch $nightly_version
-    $php_version = Invoke-RestMethod "https://raw.githubusercontent.com/php/php-src/$php_branch/main/php_version.h" | Where-Object { $_  -match 'PHP_VERSION "(.*)"' } | Foreach-Object {$Matches[1]}
-    $package_zip = "php-sdk-$sdk_version.zip"
-    $tmp_dir = "php-sdk-binary-tools-$sdk_version"
+    $script:workspace = (Get-Location).Path
+    $script:cache_dir = "C:\build-cache"
+    $script:ext_dir = "C:\projects\$extension"
+    $script:github = "https://github.com"
+    $script:trunk = "$github/shivammathur/php-builder-windows/releases/download/php$php"
+    $script:nightly_version = '8.3'
+    $script:php_branch = Get-PHPBranch $nightly_version
+    $script:php_version = Invoke-RestMethod "https://raw.githubusercontent.com/php/php-src/$php_branch/main/php_version.h" | Where-Object { $_  -match 'PHP_VERSION "(.*)"' } | Foreach-Object {$Matches[1]}
+    $script:package_zip = "php-sdk-$sdk_version.zip"
+    $script:tmp_dir = "php-sdk-binary-tools-$sdk_version"
     if($sdk_version -eq 'master') {
-        $package_zip = "master.zip"
-        $tmp_dir = "php-sdk-binary-tools-master"
+        $script:package_zip = "master.zip"
+        $script:tmp_dir = "php-sdk-binary-tools-master"
     }
-    $package_dir = "php-sdk-$sdk_version"
-    $url = "$github/php/php-sdk-binary-tools/archive/$package_zip"
-    
+    $script:package_dir = "php-sdk-$sdk_version"
+    $script:url = "$github/php/php-sdk-binary-tools/archive/$package_zip"
+
     Cleanup $ext_dir $cache_dir
     Get-BuildPackage $package_zip $url $tmp_dir $package_dir
     Get-Extension $nightly_version $ext_dir
     Build-Extension $trunk $php_version
-    Copy-Extension $workspace    
+    Copy-Extension $workspace
 }

--- a/scripts/parallel.ps1
+++ b/scripts/parallel.ps1
@@ -85,11 +85,11 @@ Function Copy-ExtensionOverride() {
     New-Item -Path $extension -ItemType "directory"
     $release_dir = Get-ReleaseDirectory
     $ext_path = [IO.Path]::Combine($ext_dir, "ext", $release_dir, "php_$extension.dll")
-    $dep_path = [IO.Path]::Combine($ext_dir, "deps", "bin", "pthreadVC2.dll")
+    # $dep_path = [IO.Path]::Combine($ext_dir, "deps", "bin", "pthreadVC2.dll")
     Write-Output "Extension Path: $ext_path"
     if(Test-Path $ext_path) {
         Copy-Item -Path $ext_path -Destination "$extension\php$php`_$ts`_$arch`_$extension.dll"
-        Copy-Item -Path $dep_path -Destination "$extension\pthreadVC2.dll"
+        # Copy-Item -Path $dep_path -Destination "$extension\pthreadVC2.dll"
         Get-ChildItem $extension
         Write-Output "Copied to $extension\php$php`_$ts`_$arch`_$extension.dll"
     } else {

--- a/scripts/parallel.ps1
+++ b/scripts/parallel.ps1
@@ -18,89 +18,56 @@ param (
     [ValidateNotNull()]
     [ValidateLength(1, [int]::MaxValue)]
     [string]
-    $config_args,
+    $dev_branch,
     [Parameter(Position = 4, Mandatory = $true)]
     [ValidateNotNull()]
     [ValidateLength(1, [int]::MaxValue)]
     [string]
-    $sdk_version,
+    $config_args,
     [Parameter(Position = 5, Mandatory = $true)]
     [ValidateNotNull()]
     [ValidateLength(1, [int]::MaxValue)]
     [string]
-    $vs,
+    $sdk_version,
     [Parameter(Position = 6, Mandatory = $true)]
     [ValidateNotNull()]
     [ValidateLength(1, [int]::MaxValue)]
     [string]
+    $vs,
+    [Parameter(Position = 7, Mandatory = $true)]
+    [ValidateNotNull()]
+    [ValidateLength(1, [int]::MaxValue)]
+    [string]
     $arch,
-    [Parameter(Position = 7, Mandatory = $false)]
+    [Parameter(Position = 8, Mandatory = $true)]
+    [ValidateNotNull()]
+    [ValidateLength(1, [int]::MaxValue)]
     [string]
     $ts,
-    [Parameter(Position = 8, Mandatory = $true)]
+    [Parameter(Position = 9, Mandatory = $true)]
     [ValidateNotNull()]
     [ValidateLength(1, [int]::MaxValue)]
     [string]
     $php
 )
 
-Function Cleanup() {
-    if(Test-Path $ext_dir) {
-        Remove-Item $ext_dir -Recurse -Force
-    }
-    if(Test-Path $cache_dir) {
-        Remove-Item $cache_dir -Recurse -Force
-    }
-    New-Item -Path $cache_dir -ItemType "directory"
+Import-Module ".\scripts\builder.psm1"
+
+$buildParams = @{
+    extension = $extension
+    repo = $repo
+    branch = $branch
+    dev_branch = $dev_branch
+    config_args = $config_args
+    sdk_version = $sdk_version
+    vs = $vs
+    arch = $arch
+    ts = $ts
+    php = $php
 }
 
-Function Get-Extension() {
-    git clone --branch=$branch $github/$repo.git $ext_dir
-}
-
-Function Get-Package {
-    param (
-        [Parameter(Position = 0, Mandatory = $true)]
-        [ValidateNotNull()]
-        [ValidateLength(1, [int]::MaxValue)]
-        [string]
-        $package,
-        [Parameter(Position = 1, Mandatory = $true)]
-        [ValidateNotNull()]
-        [ValidateLength(1, [int]::MaxValue)]
-        [string]
-        $url,
-        [Parameter(Position = 2, Mandatory = $true)]
-        [ValidateNotNull()]
-        [ValidateLength(1, [int]::MaxValue)]
-        [string]
-        $tmp_dir,
-        [Parameter(Position = 3, Mandatory = $true)]
-        [ValidateNotNull()]
-        [ValidateLength(1, [int]::MaxValue)]
-        [string]
-        $package_dir
-    )
-    if (-not (Test-Path $cache_dir\$package)) {
-        Invoke-WebRequest $url -OutFile "$cache_dir\$package"
-    }
-
-    if (-not (Test-Path $package_dir)) {
-        Expand-Archive -Path $cache_dir\$package -DestinationPath $cache_dir -Force
-        if($tmp_dir -ne $package_dir) {
-            Rename-Item -Path $cache_dir\$tmp_dir -NewName $package_dir -Force
-        }
-    }
-}
-
-Function Add-TaskFile() {
-    param (
-        [Parameter(Position = 0, Mandatory = $true)]
-        [ValidateNotNull()]
-        [ValidateLength(1, [int]::MaxValue)]
-        [string]
-        $filename
-    )
+Function Add-TaskFileOverride([string]$filename)
+{
     $bat_content = @()
     $bat_content += ""
     $bat_content += "curl -LO https://windows.php.net/downloads/pecl/deps/pthreads-2.11.0-vs16-x64.zip"
@@ -113,85 +80,25 @@ Function Add-TaskFile() {
     Set-Content -Encoding "ASCII" -Path $filename -Value $bat_content
 }
 
-Function Get-TSPath() {
-    if($ts -eq 'nts') {
-        return '-nts'
-    }
-
-    return ''
-}
-
-Function Get-ReleaseDirectory() {
-    $arch_path = ''
-    if($arch -eq 'x64') {
-        $arch_path = 'x64'
-    }
-
-    $release_path = 'Release'
-    if($ts -eq 'ts') {
-        $release_path = 'Release_TS'
-    }
-
-    return [IO.Path]::Combine($arch_path, $release_path)
-}
-
-Function Get-PHPBranch() {
-    $php_branch = 'master'
-    if($php -ne $nightly_version) {
-        $php_branch = "PHP-$php"
-    }
-
-    return $php_branch
-}
-
-Function Build-Extension() {
-    $ts_path = Get-TSPath
-    $package_zip = "php-devel-pack-$php_version$ts_path-Win32-$vs-$arch.zip"
-    $tmp_dir = "php-$php_version-devel-$vs-$arch"
-    $package_dir = "php-$php_version$ts_path-devel-$vs-$arch"
-    $url = "$trunk/$package_zip"
-    Get-Package $package_zip $url $tmp_dir $package_dir
-
-    Set-Location $ext_dir
-    Add-TaskFile "task.bat"
-    $env:PATH = "$cache_dir\$package_dir;$env:PATH"
-    $builder = "$cache_dir\php-sdk-$sdk_version\phpsdk-$vs-$arch.bat"
-    $task = (Get-Item -Path "." -Verbose).FullName + '\task.bat'
-    & $builder -t $task
-}
-
-Function Copy-Extension() {
+Function Copy-ExtensionOverride() {
     Set-Location $workspace
     New-Item -Path $extension -ItemType "directory"
     $release_dir = Get-ReleaseDirectory
-    $ext_path = [IO.Path]::Combine($ext_dir, $release_dir, "php_$extension.dll")
+    $ext_path = [IO.Path]::Combine($ext_dir, "ext", $release_dir, "php_$extension.dll")
+    $dep_path = [IO.Path]::Combine($ext_dir, "deps", "bin", "pthreadVC2.dll")
     Write-Output "Extension Path: $ext_path"
     if(Test-Path $ext_path) {
         Copy-Item -Path $ext_path -Destination "$extension\php$php`_$ts`_$arch`_$extension.dll"
+        Copy-Item -Path $dep_path -Destination "$extension\pthreadVC2.dll"
         Get-ChildItem $extension
+        Write-Output "Copied to $extension\php$php`_$ts`_$arch`_$extension.dll"
     } else {
+        Write-Output "File '$ext_path' does not exist!"
         exit 1
     }
 }
 
-$workspace = (Get-Location).Path
-$cache_dir = "C:\build-cache"
-$ext_dir = "C:\projects\$extension"
-$github = "https://github.com"
-$trunk = "$github/shivammathur/php-builder-windows/releases/download/php$php"
-$nightly_version = '8.3'
-$php_branch = Get-PHPBranch
-$php_version = Invoke-RestMethod "https://raw.githubusercontent.com/php/php-src/$php_branch/main/php_version.h" | Where-Object { $_  -match 'PHP_VERSION "(.*)"' } | Foreach-Object {$Matches[1]}
-$package_zip = "php-sdk-$sdk_version.zip"
-$tmp_dir = "php-sdk-binary-tools-php-sdk-$sdk_version"
-if($sdk_version -eq 'master') {
-    $package_zip = "master.zip"
-    $tmp_dir = "php-sdk-binary-tools-master"
-}
-$package_dir = "php-sdk-$sdk_version"
-$url = "$github/php/php-sdk-binary-tools/archive/$package_zip"
-Cleanup
-Get-Package $package_zip $url $tmp_dir $package_dir
-Get-Extension
-Build-Extension
-Copy-Extension
+
+Set-Alias -Name "Add-TaskFile" -Value "Add-TaskFileOverride"
+
+RunBuilder $buildParams

--- a/scripts/tensor.ps1
+++ b/scripts/tensor.ps1
@@ -18,91 +18,56 @@ param (
     [ValidateNotNull()]
     [ValidateLength(1, [int]::MaxValue)]
     [string]
-    $config_args,
+    $dev_branch,
     [Parameter(Position = 4, Mandatory = $true)]
     [ValidateNotNull()]
     [ValidateLength(1, [int]::MaxValue)]
     [string]
-    $sdk_version,
+    $config_args,
     [Parameter(Position = 5, Mandatory = $true)]
     [ValidateNotNull()]
     [ValidateLength(1, [int]::MaxValue)]
     [string]
-    $vs,
+    $sdk_version,
     [Parameter(Position = 6, Mandatory = $true)]
     [ValidateNotNull()]
     [ValidateLength(1, [int]::MaxValue)]
     [string]
+    $vs,
+    [Parameter(Position = 7, Mandatory = $true)]
+    [ValidateNotNull()]
+    [ValidateLength(1, [int]::MaxValue)]
+    [string]
     $arch,
-    [Parameter(Position = 7, Mandatory = $false)]
+    [Parameter(Position = 8, Mandatory = $true)]
+    [ValidateNotNull()]
+    [ValidateLength(1, [int]::MaxValue)]
     [string]
     $ts,
-    [Parameter(Position = 8, Mandatory = $true)]
+    [Parameter(Position = 9, Mandatory = $true)]
     [ValidateNotNull()]
     [ValidateLength(1, [int]::MaxValue)]
     [string]
     $php
 )
 
-Function Cleanup() {
-    if(Test-Path $ext_dir) {
-        Remove-Item $ext_dir -Recurse -Force
-    }
-    if(Test-Path $cache_dir) {
-        Remove-Item $cache_dir -Recurse -Force
-    }
-    New-Item -Path $cache_dir -ItemType "directory"
+Import-Module ".\scripts\builder.psm1"
+
+$buildParams = @{
+    extension = $extension
+    repo = $repo
+    branch = $branch
+    dev_branch = $dev_branch
+    config_args = $config_args
+    sdk_version = $sdk_version
+    vs = $vs
+    arch = $arch
+    ts = $ts
+    php = $php
 }
 
-Function Get-Extension() {
-    git clone --branch=$branch $github/$repo.git $ext_dir
-    # git clone --branch=$branch $github/$repo.git $ext_dir-project
-    # Move-Item "C:/projects/tensor-project/ext" "C:/projects/tensor"
-}
-
-Function Get-Package {
-    param (
-        [Parameter(Position = 0, Mandatory = $true)]
-        [ValidateNotNull()]
-        [ValidateLength(1, [int]::MaxValue)]
-        [string]
-        $package,
-        [Parameter(Position = 1, Mandatory = $true)]
-        [ValidateNotNull()]
-        [ValidateLength(1, [int]::MaxValue)]
-        [string]
-        $url,
-        [Parameter(Position = 2, Mandatory = $true)]
-        [ValidateNotNull()]
-        [ValidateLength(1, [int]::MaxValue)]
-        [string]
-        $tmp_dir,
-        [Parameter(Position = 3, Mandatory = $true)]
-        [ValidateNotNull()]
-        [ValidateLength(1, [int]::MaxValue)]
-        [string]
-        $package_dir
-    )
-    if (-not (Test-Path $cache_dir\$package)) {
-        Invoke-WebRequest $url -OutFile "$cache_dir\$package"
-    }
-
-    if (-not (Test-Path $package_dir)) {
-        Expand-Archive -Path $cache_dir\$package -DestinationPath $cache_dir -Force
-        if($tmp_dir -ne $package_dir) {
-            Rename-Item -Path $cache_dir\$tmp_dir -NewName $package_dir -Force
-        }
-    }
-}
-
-Function Add-TaskFile1() {
-    param (
-        [Parameter(Position = 0, Mandatory = $true)]
-        [ValidateNotNull()]
-        [ValidateLength(1, [int]::MaxValue)]
-        [string]
-        $filename
-    )
+Function Add-TaskFile1([string]$filename)
+{
     $bat_content = @()
     $bat_content += ""
     $bat_content += "curl -LO https://github.com/xianyi/OpenBLAS/releases/download/v0.3.21/OpenBLAS-0.3.21-x64.zip"
@@ -111,31 +76,18 @@ Function Add-TaskFile1() {
     Set-Content -Encoding "ASCII" -Path $filename -Value $bat_content
 }
 
-Function Add-TaskFile2() {
-    param (
-        [Parameter(Position = 0, Mandatory = $true)]
-        [ValidateNotNull()]
-        [ValidateLength(1, [int]::MaxValue)]
-        [string]
-        $filename
-    )
+Function Add-TaskFile2([string]$filename)
+{
     $bat_content = @()
     $bat_content += ""
     $bat_content += "call phpize 2>&1"
     $bat_content += "call configure --help"
-    # $bat_content += "call configure --$config_args --enable-debug-pack 2>&1"
-    $bat_content += "call configure --$config_args 2>&1"
+    $bat_content += "call configure --$config_args --enable-debug-pack 2>&1"
     Set-Content -Encoding "ASCII" -Path $filename -Value $bat_content
 }
 
-Function Add-TaskFile3() {
-    param (
-        [Parameter(Position = 0, Mandatory = $true)]
-        [ValidateNotNull()]
-        [ValidateLength(1, [int]::MaxValue)]
-        [string]
-        $filename
-    )
+Function Add-TaskFile3([string]$filename)
+{
     $bat_content = @()
     $bat_content += ""
     $bat_content += "nmake /nologo 2>&1"
@@ -143,44 +95,13 @@ Function Add-TaskFile3() {
     Set-Content -Encoding "ASCII" -Path $filename -Value $bat_content
 }
 
-Function Get-TSPath() {
-    if($ts -eq 'nts') {
-        return '-nts'
-    }
-
-    return ''
-}
-
-Function Get-ReleaseDirectory() {
-    $arch_path = ''
-    if($arch -eq 'x64') {
-        $arch_path = 'x64'
-    }
-
-    $release_path = 'Release'
-    if($ts -eq 'ts') {
-        $release_path = 'Release_TS'
-    }
-
-    return [IO.Path]::Combine($arch_path, $release_path)
-}
-
-Function Get-PHPBranch() {
-    $php_branch = 'master'
-    if($php -ne $nightly_version) {
-        $php_branch = "PHP-$php"
-    }
-
-    return $php_branch
-}
-
-Function Build-Extension() {
+Function Build-ExtensionOverride([string]$trunk, [string]$php_version) {
     $ts_path = Get-TSPath
     $package_zip = "php-devel-pack-$php_version$ts_path-Win32-$vs-$arch.zip"
     $tmp_dir = "php-$php_version-devel-$vs-$arch"
     $package_dir = "php-$php_version$ts_path-devel-$vs-$arch"
     $url = "$trunk/$package_zip"
-    Get-Package $package_zip $url $tmp_dir $package_dir
+    Get-BuildPackage $package_zip $url $tmp_dir $package_dir
 
     Set-Location "$ext_dir\ext"
     Add-TaskFile1 "task1.bat"
@@ -203,14 +124,16 @@ Function Build-Extension() {
     & $builder -t $task3
 }
 
-Function Copy-Extension() {
+Function Copy-ExtensionOverride([string]$workspace) {
     Set-Location $workspace
     New-Item -Path $extension -ItemType "directory"
     $release_dir = Get-ReleaseDirectory
     $ext_path = [IO.Path]::Combine($ext_dir, "ext", $release_dir, "php_$extension.dll")
+    $dep_path = [IO.Path]::Combine($ext_dir, "deps", "bin", "libopenblas.dll")
     Write-Output "Extension Path: $ext_path"
     if(Test-Path $ext_path) {
         Copy-Item -Path $ext_path -Destination "$extension\php$php`_$ts`_$arch`_$extension.dll"
+        Copy-Item -Path $dep_path -Destination "$extension\libopenblas.dll"
         Get-ChildItem $extension
         Write-Output "Copied to $extension\php$php`_$ts`_$arch`_$extension.dll"
     } else {
@@ -219,24 +142,7 @@ Function Copy-Extension() {
     }
 }
 
-$workspace = (Get-Location).Path
-$cache_dir = "C:\build-cache"
-$ext_dir = "C:\projects\$extension"
-$github = "https://github.com"
-$trunk = "$github/shivammathur/php-builder-windows/releases/download/php$php"
-$nightly_version = '8.3'
-$php_branch = Get-PHPBranch
-$php_version = Invoke-RestMethod "https://raw.githubusercontent.com/php/php-src/$php_branch/main/php_version.h" | Where-Object { $_  -match 'PHP_VERSION "(.*)"' } | Foreach-Object {$Matches[1]}
-$package_zip = "php-sdk-$sdk_version.zip"
-$tmp_dir = "php-sdk-binary-tools-php-sdk-$sdk_version"
-if($sdk_version -eq 'master') {
-    $package_zip = "master.zip"
-    $tmp_dir = "php-sdk-binary-tools-master"
-}
-$package_dir = "php-sdk-$sdk_version"
-$url = "$github/php/php-sdk-binary-tools/archive/$package_zip"
-Cleanup
-Get-Package $package_zip $url $tmp_dir $package_dir
-Get-Extension
-Build-Extension
-Copy-Extension
+Set-Alias -Name "Build-Extension" -Value "Build-ExtensionOverride"
+Set-Alias -Name "Copy-Extension" -Value "Copy-ExtensionOverride"
+
+RunBuilder $buildParams

--- a/scripts/tensor.ps1
+++ b/scripts/tensor.ps1
@@ -129,11 +129,11 @@ Function Copy-ExtensionOverride([string]$workspace) {
     New-Item -Path $extension -ItemType "directory"
     $release_dir = Get-ReleaseDirectory
     $ext_path = [IO.Path]::Combine($ext_dir, "ext", $release_dir, "php_$extension.dll")
-    $dep_path = [IO.Path]::Combine($ext_dir, "deps", "bin", "libopenblas.dll")
+    # $dep_path = [IO.Path]::Combine($ext_dir, "deps", "bin", "libopenblas.dll")
     Write-Output "Extension Path: $ext_path"
     if(Test-Path $ext_path) {
         Copy-Item -Path $ext_path -Destination "$extension\php$php`_$ts`_$arch`_$extension.dll"
-        Copy-Item -Path $dep_path -Destination "$extension\libopenblas.dll"
+        # Copy-Item -Path $dep_path -Destination "$extension\libopenblas.dll"
         Get-ChildItem $extension
         Write-Output "Copied to $extension\php$php`_$ts`_$arch`_$extension.dll"
     } else {


### PR DESCRIPTION
The goal of this change is to better organize the code to reduce code reuse. This has come up because I've decided to split every extension into its own build workflow. The amount of complication that would be needed to keep everything in a single workflow, given what is needed to build Tensor and Parallel, is just too much.